### PR TITLE
Implement alias

### DIFF
--- a/changes/66.feature.rst
+++ b/changes/66.feature.rst
@@ -1,0 +1,10 @@
+Implemented ability to alias macros, eg.:
+
+.. code-block::
+
+    numbers = {"one", "two", "three"}
+    @alias IN_LIST IL
+
+    IL(numbers) -> MARK("NUMBER")
+
+Now using "IL" will actually call "IN_LIST" macro.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -22,3 +22,16 @@ ComplexNumber = {NUM+, WORD("/")?, NUM?}
 {PATTERN(ComplexNumber), WORD("inches"), WORD("Height")}->MARK("HEIGHT")
 {PATTERN(ComplexNumber), WORD("inches"), WORD("Width")}->MARK("WIDTH")
 ```
+
+# Alias
+
+You can alias frequently used macros to make their names shorter:
+
+```
+numbers = {"one", "two", "three"}
+@alias IN_LIST IL
+
+IL(numbers) -> MARK("NUMBER")
+```
+
+Now using "IL" will actually call "IN_LIST" macro. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rita-dsl"
-version = "0.5.0"
+version = "0.5.1"
 description = "DSL for building language rules"
 authors = [
     "Šarūnas Navickas <zaibacu@gmail.com>"

--- a/rita/__init__.py
+++ b/rita/__init__.py
@@ -10,7 +10,7 @@ from rita.precompile import precompile
 
 logger = logging.getLogger(__name__)
 
-__version__ = (0, 5, 0, os.getenv("VERSION_PATCH"))
+__version__ = (0, 5, 1, os.getenv("VERSION_PATCH"))
 
 
 def get_version():

--- a/rita/precompile.py
+++ b/rita/precompile.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 MAX_DEPTH = 5
+ALIAS_PATTERN = re.compile(r"@alias\s+(?P<original>(\w|[_])+)\s+(?P<alias>(\w|[_])+)")
 
 
 def handle_import(m, depth=0):
@@ -29,4 +30,14 @@ def precompile(raw, depth=0):
         partial(handle_import, depth=depth),
         raw
     )
+
+    for m in ALIAS_PATTERN.finditer(raw):
+        # Delete alias definition
+        full = m.group(0)
+        raw = raw.replace(full, "")
+
+        original = m.group("original")
+        alias = m.group("alias")
+        raw = raw.replace(alias, original)
+
     return raw

--- a/tests/test_precompile.py
+++ b/tests/test_precompile.py
@@ -29,16 +29,15 @@ def test_alias():
     numbers = {"one", "two", "three"}
     @alias IN_LIST IL
     @alias MARK M
-    
+
     IL(numbers)->M("HELLO")
     """
 
     expected = """
-    numbers = {"one", "two", "three"}    
+    numbers = {"one", "two", "three"}
 
     IN_LIST(numbers)->MARK("HELLO")
     """
 
     result = precompile(rules.strip())
     raw_compare(expected, result)
-

--- a/tests/test_precompile.py
+++ b/tests/test_precompile.py
@@ -2,6 +2,8 @@ import pytest
 
 from rita.precompile import precompile
 
+from utils import raw_compare
+
 
 def test_rule_import():
     rules = """
@@ -20,3 +22,23 @@ def test_cyclical_import():
 
     with pytest.raises(RuntimeError):
         precompile(rules)
+
+
+def test_alias():
+    rules = """
+    numbers = {"one", "two", "three"}
+    @alias IN_LIST IL
+    @alias MARK M
+    
+    IL(numbers)->M("HELLO")
+    """
+
+    expected = """
+    numbers = {"one", "two", "three"}    
+
+    IN_LIST(numbers)->MARK("HELLO")
+    """
+
+    result = precompile(rules.strip())
+    raw_compare(expected, result)
+

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 import rita
 
@@ -30,3 +32,14 @@ def standalone_engine(rules):
         results = list(parser.execute(text))
         return list([(r["text"], r["label"]) for r in results])
     return parse
+
+
+def normalize_output(r):
+    return re.sub(r"\s+", " ", r.strip().replace("\n", ""))
+
+
+def raw_compare(r1, r2):
+    r1 = normalize_output(r1)
+    r2 = normalize_output(r2)
+
+    assert r1 == r2


### PR DESCRIPTION
Closes: https://github.com/zaibacu/rita-dsl/issues/65

Implemented ability to alias macros, eg.:

```
numbers = {"one", "two", "three"}
@alias IN_LIST IL

IL(numbers) -> MARK("NUMBER")
```

Now using "IL" will actually call "IN_LIST" macro. 