### PR TITLE
Fix sequencial optional

### DIFF
--- a/changes/71.fix.rst
+++ b/changes/71.fix.rst
@@ -1,0 +1,1 @@
+Fix `-` bug when it is used as stand alone word

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rita-dsl"
-version = "0.5.3"
+version = "0.5.4"
 description = "DSL for building language rules"
 authors = [
     "Šarūnas Navickas <zaibacu@gmail.com>"

--- a/rita/__init__.py
+++ b/rita/__init__.py
@@ -10,7 +10,7 @@ from rita.precompile import precompile
 
 logger = logging.getLogger(__name__)
 
-__version__ = (0, 5, 3, os.getenv("VERSION_PATCH"))
+__version__ = (0, 5, 4, os.getenv("VERSION_PATCH"))
 
 
 def get_version():

--- a/rita/preprocess.py
+++ b/rita/preprocess.py
@@ -113,6 +113,10 @@ def handle_multi_word(rules, config):
 
 
 def is_complex(arg):
+    # if we want to use `-` as a word
+    if arg.strip() == "-":
+        return False
+
     splitters = ["-", " "]
     return any([s in arg
                 for s in splitters])

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -252,6 +252,27 @@ class TestSpacy(object):
             "pattern": [{"LOWER": {"REGEX": ".*"}}]
         }
 
+    def test_multiple_optionals(self):
+        rules = self.compiler("""
+        {NUM+, WORD("-")?, NUM?, WORD("/")?, NUM?}->MARK("NUMBER_PATTERN")
+        """)
+        print(rules)
+        assert len(rules) == 1
+        assert rules[0] == {
+            "label": "NUMBER_PATTERN",
+            "pattern": [
+                {"LOWER": {"REGEX": "\\d+[.]?\\d*"}, "OP": "+"},
+                {"IS_PUNCT": True, "OP": "?"},
+                {"LOWER": "-", "OP": "?"},
+                {"IS_PUNCT": True, "OP": "?"},
+                {"LOWER": {"REGEX": "\\d+[.]?\\d*"}, "OP": "?"},
+                {"IS_PUNCT": True, "OP": "?"},
+                {"LOWER": "/", "OP": "?"},
+                {"IS_PUNCT": True, "OP": "?"},
+                {"LOWER": {"REGEX": "\\d+[.]?\\d*"}, "OP": "?"},
+            ]
+        }
+
 
 class TestStandalone(object):
     @property


### PR DESCRIPTION
Closes https://github.com/zaibacu/rita-dsl/issues/69

Turns out it is a bug related to `-` character which in most cases used as a splitter, but in this case as a stand alone word