### PR TITLE
Feature/regex tag

### DIFF
--- a/rita/engine/translate_spacy.py
+++ b/rita/engine/translate_spacy.py
@@ -74,6 +74,18 @@ def phrase_parse(value, config, op=None):
         yield generic_parse("ORTH", value, config=config, op=None)
 
 
+def tag_parse(r, config, op=None):
+    """
+    For generating POS/TAG patterns based on a Regex
+    e.g. TAG("^NN|^JJ") for adjectives or nouns
+    """
+    d = {"TAG": {"REGEX": r}}
+
+    if op:
+        d["OP"] = op
+    yield d
+
+
 PARSERS = {
     "any_of": any_of_parse,
     "value": partial(generic_parse, "ORTH"),
@@ -84,6 +96,7 @@ PARSERS = {
     "punct": punct_parse,
     "fuzzy": fuzzy_parse,
     "phrase": phrase_parse,
+    "tag": tag_parse,
 }
 
 

--- a/rita/modules/tag.py
+++ b/rita/modules/tag.py
@@ -1,0 +1,8 @@
+from rita.macros import resolve_value
+
+def TAG(name, config, op=None):
+    """
+    For generating POS/TAG patterns based on a Regex
+    e.g. TAG("^NN|^JJ") for nouns or adjectives
+    """
+    return "tag", resolve_value(name, config=config), op


### PR DESCRIPTION
This feature would introduce the TAG element as a module. Needs a new parser for the SpaCy translate. 
Would allow more flexible matching of detailed part-of-speech tag, like all adjectives or nouns: `TAG("^NN|^JJ")`.