### PR TITLE
Use word boundary for list

### DIFF
--- a/changes/91.fix.rst
+++ b/changes/91.fix.rst
@@ -1,0 +1,1 @@
+Switch from `(^\s)` to `\b` when doing `IN_LIST`. Should solve several corner cases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rita-dsl"
-version = "0.6.2"
+version = "0.6.3"
 description = "DSL for building language rules"
 authors = [
     "Šarūnas Navickas <zaibacu@gmail.com>"

--- a/rita/__init__.py
+++ b/rita/__init__.py
@@ -10,7 +10,7 @@ from rita.precompile import precompile
 
 logger = logging.getLogger(__name__)
 
-__version__ = (0, 6, 2, os.getenv("VERSION_PATCH"))
+__version__ = (0, 6, 3, os.getenv("VERSION_PATCH"))
 
 
 def get_version():

--- a/rita/engine/translate_standalone.py
+++ b/rita/engine/translate_standalone.py
@@ -21,7 +21,7 @@ def apply_operator(syntax, op):
 
 
 def any_of_parse(lst, op=None):
-    clause = r"(^|\s)(({0})\s?)".format("|".join(sorted(lst, key=lambda x: (-len(x), x))))
+    clause = r"\b(({0})\s?)".format("|".join(sorted(lst, key=lambda x: (-len(x), x))))
     return "(" + apply_operator(clause, op) + ")"
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -340,7 +340,7 @@ class TestStandalone(object):
         ''')
         print(rules)
         assert len(rules) == 1
-        assert rules[0] == re.compile(r"(?P<MULTI_LABEL>((^|\s)((test1|test2)\s?)))", self.flags)
+        assert rules[0] == re.compile(r"(?P<MULTI_LABEL>(\b((test1|test2)\s?)))", self.flags)
 
     def test_simple_pattern(self):
         rules = self.compiler('''
@@ -378,19 +378,19 @@ class TestStandalone(object):
         print(rules)
         assert len(rules) == 4
         assert rules[0] == re.compile(
-            r"(?P<MULTI_SPLIT_LABEL>(test1\s?)([.,!;?:]\s?)?((^|\s)((three|one|two)\s?))([.,!;?:]\s?)?(test3\s?))",
+            r"(?P<MULTI_SPLIT_LABEL>(test1\s?)([.,!;?:]\s?)?(\b((three|one|two)\s?))([.,!;?:]\s?)?(test3\s?))",
             self.flags
         )
         assert rules[1] == re.compile(
-            r"(?P<MULTI_SPLIT_LABEL>(test2\s?)([.,!;?:]\s?)?((^|\s)((three|one|two)\s?))([.,!;?:]\s?)?(test3\s?))",
+            r"(?P<MULTI_SPLIT_LABEL>(test2\s?)([.,!;?:]\s?)?(\b((three|one|two)\s?))([.,!;?:]\s?)?(test3\s?))",
             self.flags
         )
         assert rules[2] == re.compile(
-            r"(?P<MULTI_SPLIT_LABEL>(test1\s?)([.,!;?:]\s?)?((^|\s)((three|one|two)\s?))([.,!;?:]\s?)?(test4\s?))",
+            r"(?P<MULTI_SPLIT_LABEL>(test1\s?)([.,!;?:]\s?)?(\b((three|one|two)\s?))([.,!;?:]\s?)?(test4\s?))",
             self.flags
         )
         assert rules[3] == re.compile(
-            r"(?P<MULTI_SPLIT_LABEL>(test2\s?)([.,!;?:]\s?)?((^|\s)((three|one|two)\s?))([.,!;?:]\s?)?(test4\s?))",
+            r"(?P<MULTI_SPLIT_LABEL>(test2\s?)([.,!;?:]\s?)?(\b((three|one|two)\s?))([.,!;?:]\s?)?(test4\s?))",
             self.flags
         )
 
@@ -400,7 +400,7 @@ class TestStandalone(object):
         ''')
         print(rules)
         assert len(rules) == 1
-        assert rules[0] == re.compile(r"(?P<TWO_WORDS>((^|\s)((Sarunas|Šarūnas)\s?)))", self.flags)
+        assert rules[0] == re.compile(r"(?P<TWO_WORDS>(\b((Sarunas|Šarūnas)\s?)))", self.flags)
 
     def test_list_with_accent(self):
         rules = self.compiler('''
@@ -409,7 +409,7 @@ class TestStandalone(object):
         ''')
         print(rules)
         assert len(rules) == 1
-        assert rules[0] == re.compile(r"(?P<EXTENDED_LIST>((^|\s)((Sarunas|Šarūnas|Jurgis|Jonas)\s?)))", self.flags)
+        assert rules[0] == re.compile(r"(?P<EXTENDED_LIST>(\b((Sarunas|Šarūnas|Jurgis|Jonas)\s?)))", self.flags)
 
     def test_double_op(self):
         rules = self.compiler('''
@@ -434,7 +434,7 @@ class TestStandalone(object):
         ''')
         print(rules)
         assert len(rules) == 1
-        assert rules[0] == re.compile(r"(?P<META_LIST>((^|\s)((metamathematics|metaphysics)\s?)))", self.flags)
+        assert rules[0] == re.compile(r"(?P<META_LIST>(\b((metamathematics|metaphysics)\s?)))", self.flags)
 
     def test_prefix_on_unknown_type(self):
         rules = self.compiler('''
@@ -464,7 +464,7 @@ class TestStandalone(object):
         print(rules)
 
         assert len(rules) == 1
-        assert rules[0] == re.compile(r"(?P<OPTIONAL_LIST>((^|\s)((one|two)\s?)?))", self.flags)
+        assert rules[0] == re.compile(r"(?P<OPTIONAL_LIST>(\b((one|two)\s?)?))", self.flags)
 
     def test_complex_list(self):
         rules = self.compiler("""


### PR DESCRIPTION
Switch from `(^\s)` to `\b` should solve several corner cases