### PR TITLE
Add Orth module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a language, loosely based on language [Apache UIMA RUTA](https://uima.ap
 [![Intro](https://img.youtube.com/vi/GScerMeWz68/0.jpg)](https://www.youtube.com/watch?v=GScerMeWz68)
 
 ## Links
-- [Live Demo](https://rita-demo.herokuapp.com/)
+- [Live Demo](https://rita-dsl.io/#demo)
 - [Simple Chat bot example](https://repl.it/talk/share/Simple-chatbot-done-with-Rita/53471)
 - [Documentation](http://rita-dsl.readthedocs.io/)
 - [QuickStart](https://rita-dsl.readthedocs.io/en/latest/quickstart/)

--- a/changes/102.feature.rst
+++ b/changes/102.feature.rst
@@ -1,0 +1,3 @@
+ORTH module which allows you to specify case sensitive entry while rest of the rules ignores case. Used for acronyms and proper names
+
+Implemented by: Roland M. Mueller (https://github.com/rolandmueller)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -54,3 +54,19 @@ Usage:
 
 {WORD*, TAG("^NN|^JJ")}->MARK("TAGGED_MATCH")
 ```
+
+## Orth
+
+Ignores case-insensitive configuration and checks words as written
+that means case-sensitive even if configuration is case-insensitive.
+Especially useful for acronyms and proper names. 
+
+Works only with spaCy engine
+
+Usage:
+
+```
+!IMPORT("rita.modules.orth")
+
+{ORTH("IEEE")}->MARK("TAGGED_MATCH")
+```

--- a/rita/engine/translate_spacy.py
+++ b/rita/engine/translate_spacy.py
@@ -93,6 +93,14 @@ def nested_parse(values, config, op=None):
     return results["pattern"]
 
 
+def orth_parse(value, config, op=None):
+    d = {}
+    d["ORTH"] = value
+    if op:
+        d["OP"] = op
+    yield d
+
+
 PARSERS = {
     "any_of": any_of_parse,
     "value": partial(generic_parse, "ORTH"),
@@ -105,6 +113,7 @@ PARSERS = {
     "phrase": phrase_parse,
     "tag": tag_parse,
     "nested": nested_parse,
+    "orth": orth_parse,
 }
 
 

--- a/rita/modules/orth.py
+++ b/rita/modules/orth.py
@@ -1,6 +1,3 @@
-from rita.macros import resolve_value
-
-
 def ORTH(value, config, op=None):
     """
     Ignores case-insensitive configuration and checks words as written

--- a/rita/modules/orth.py
+++ b/rita/modules/orth.py
@@ -1,0 +1,9 @@
+from rita.macros import resolve_value
+
+
+def ORTH(value, config, op=None):
+    """
+    Ignores case-insensitive configuration and checks words as written
+    that means case-sensitive even if configuration is case-insensitive
+    """
+    return "orth", value, op

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -345,10 +345,12 @@ def test_orth_example(engine):
     !IMPORT("rita.modules.orth")
 
     {ORTH("IEEE")}->MARK("TAGGED_MATCH")
+    {ORTH("ISO")?}->MARK("TAGGED_MATCH")
     """)
 
     text = """
-    it should match IEEE, but should ignore ieee
+    it should match IEEE or ISO, but should ignore ieee.
+    
     """
 
     results = set([text
@@ -356,8 +358,8 @@ def test_orth_example(engine):
                    if label == "TAGGED_MATCH"])
 
     print(results)
-    assert len(results) == 1
-    assert {"IEEE"} == results
+    assert len(results) == 2
+    assert {"IEEE", "ISO"} == results
 
 
 @pytest.mark.parametrize('engine', [standalone_engine, spacy_engine, rust_engine])

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -339,6 +339,26 @@ def test_pluralize(engine):
     assert {"7 cars", "2 motorbikes", "1 ship", "1 bicycle", "9 planes"} == results
 
 
+@pytest.mark.parametrize('engine', [spacy_engine])
+def test_orth_example(engine):
+    parser = engine("""
+    !IMPORT("rita.modules.orth")
+
+    {ORTH("IEEE")}->MARK("TAGGED_MATCH")
+    """)
+
+    text = """
+    it should match IEEE, but should ignore ieee
+    """
+
+    results = set([text
+                   for text, label in parser(text)
+                   if label == "TAGGED_MATCH"])
+    print(results)
+    assert len(results) == 1
+    assert {"IEEE"} == results
+
+
 @pytest.mark.parametrize('engine', [standalone_engine])
 def test_custom_regex_impl(engine):
     import re

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -350,7 +350,6 @@ def test_orth_example(engine):
 
     text = """
     it should match IEEE or ISO, but should ignore ieee.
-    
     """
 
     results = set([text

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -350,15 +350,15 @@ def test_orth_example(engine):
     text = """
     it should match IEEE, but should ignore ieee
     """
-    
+
     results = set([text
                    for text, label in parser(text)
                    if label == "TAGGED_MATCH"])
-    
+
     print(results)
     assert len(results) == 1
     assert {"IEEE"} == results
- 
+
 
 @pytest.mark.parametrize('engine', [standalone_engine, spacy_engine, rust_engine])
 def test_regex_module_start(engine):


### PR DESCRIPTION
This feature would introduce the ORTH element as a module.

Ignores case-insensitive configuration and checks words as written
that means case-sensitive even if configuration is case-insensitive.
Especially useful for acronyms and proper names. 

Works only with spaCy engine

Usage:

```
!IMPORT("rita.modules.orth")

{ORTH("IEEE")}->MARK("TAGGED_MATCH")
```