### PR TITLE
Add TAG_WORD macro to Tag module

### DIFF
--- a/changes/103.feature.rst
+++ b/changes/103.feature.rst
@@ -1,0 +1,3 @@
+Additional macro for `tag` module, allowing to tag specific word/list of words
+
+Implemented by: Roland M. Mueller (https://github.com/rolandmueller)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -42,8 +42,11 @@ vehicles={"car", "motorbike", "bicycle", "ship", "plane"}
 
 ## Tag
 
-Is used or generating POS/TAG patterns based on a Regex
-e.g. TAG("^NN|^JJ") for nouns or adjectives.
+This module offers two new macros: `TAG` and `TAG_WORD`.
+
+
+`TAG` is used for generating POS/TAG patterns based on a Regex
+e.g. `TAG("^NN|^JJ")` for nouns or adjectives.
 
 Works only with spaCy engine
 
@@ -53,4 +56,23 @@ Usage:
 !IMPORT("rita.modules.tag")
 
 {WORD*, TAG("^NN|^JJ")}->MARK("TAGGED_MATCH")
+```
+
+`TAG_WORD` is for generating TAG patterns with a word or a list.
+
+e.g. match only "proposed" when it is in the sentence a verb (and not an adjective):
+
+```
+!IMPORT("rita.modules.tag")
+
+TAG_WORD("^VB", "proposed")
+```
+
+or e.g. match a list of words only to verbs
+
+```
+!IMPORT("rita.modules.tag")
+
+words = {"percived", "proposed"}
+{TAG_WORD("^VB", words)?}->MARK("LABEL")
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rita-dsl"
-version = "0.6.9"
+version = "0.6.10"
 description = "DSL for building language rules"
 authors = [
     "Šarūnas Navickas <zaibacu@gmail.com>"

--- a/rita/__init__.py
+++ b/rita/__init__.py
@@ -10,7 +10,7 @@ from rita.precompile import precompile
 
 logger = logging.getLogger(__name__)
 
-__version__ = (0, 6, 9, os.getenv("VERSION_PATCH"))
+__version__ = (0, 6, 10, os.getenv("VERSION_PATCH"))
 
 
 def get_version():

--- a/rita/engine/translate_spacy.py
+++ b/rita/engine/translate_spacy.py
@@ -91,7 +91,7 @@ def tag_parse(values, config, op=None):
         if config.ignore_case:
             normalized = sorted([item.lower()
                                  for item in lst])
-            d["LOWER"] =  {"REGEX": r"^({0})$".format("|".join(normalized))}
+            d["LOWER"] = {"REGEX": r"^({0})$".format("|".join(normalized))}
         else:
             d["TEXT"] = {"REGEX": r"^({0})$".format("|".join(sorted(lst)))}
     if op:

--- a/rita/engine/translate_spacy.py
+++ b/rita/engine/translate_spacy.py
@@ -74,13 +74,26 @@ def phrase_parse(value, config, op=None):
         yield generic_parse("ORTH", value, config=config, op=None)
 
 
-def tag_parse(r, config, op=None):
+def tag_parse(values, config, op=None):
     """
     For generating POS/TAG patterns based on a Regex
     e.g. TAG("^NN|^JJ") for adjectives or nouns
+    also deals with TAG_WORD for tag and word or tag and list
     """
-    d = {"TAG": {"REGEX": r}}
-
+    d = {"TAG": {"REGEX": values["tag"]}}
+    if "word" in values:
+        if config.ignore_case:
+            d["LOWER"] = values["word"].lower()
+        else:
+            d["TEXT"] = values["word"]
+    elif "list" in values:
+        lst = values["list"]
+        if config.ignore_case:
+            normalized = sorted([item.lower()
+                                 for item in lst])
+            d["LOWER"] =  {"REGEX": r"^({0})$".format("|".join(normalized))}
+        else:
+            d["TEXT"] = {"REGEX": r"^({0})$".format("|".join(sorted(lst)))}
     if op:
         d["OP"] = op
     yield d

--- a/rita/modules/tag.py
+++ b/rita/modules/tag.py
@@ -1,9 +1,27 @@
 from rita.macros import resolve_value
 
 
-def TAG(name, config, op=None):
+def TAG(tag, config, op=None):
     """
     For generating POS/TAG patterns based on a Regex
     e.g. TAG("^NN|^JJ") for nouns or adjectives
     """
-    return "tag", resolve_value(name, config=config), op
+    values = {"tag": tag}
+    return "tag", values, op
+
+
+def TAG_WORD(tag, value, config, op=None):
+    """
+    For generating TAG patterns with a word or a list
+    e.g. match only "proposed" when it is in the sentence a verb (and not an adjective):
+    TAG_WORD("^VB", "proposed")
+    e.g. match a list of words only to verbs
+    words = {"percived", "proposed"}
+    {TAG_WORD("^VB", words)?}->MARK("LABEL")
+    """
+    values = {"tag": tag}
+    if type(value) == list:
+        values["list"] = value
+    else:
+        values["word"] = value
+    return "tag", values, op

--- a/rita/modules/tag.py
+++ b/rita/modules/tag.py
@@ -1,6 +1,3 @@
-from rita.macros import resolve_value
-
-
 def TAG(tag, config, op=None):
     """
     For generating POS/TAG patterns based on a Regex

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -333,6 +333,31 @@ class TestSpacy(object):
             "pattern": [{"LOWER": {"REGEX": "^(perceived|proposed)$"}, "TAG": {"REGEX": "^VB"}}]
         }
 
+    def test_tags_case_sensitive(self):
+        rules = self.compiler("""
+        !CONFIG("ignore_case", "F")
+        !IMPORT("rita.modules.tag")
+
+        words = {"perceived", "proposed"}
+        TAG_WORD("^VB", "proposed")->MARK("TEST_TAG")
+        {TAG_WORD("^VB", words)}->MARK("TEST_TAG")
+        """)
+
+        print(rules)
+
+        assert len(rules) == 2
+        assert rules == [
+            {
+                "label": "TEST_TAG",
+                "pattern": [{"TEXT": "proposed", "TAG": {"REGEX": "^VB"}}]
+            },
+            {
+                "label": "TEST_TAG",
+                "pattern": [{"TEXT": {"REGEX": "^(perceived|proposed)$"}, "TAG": {"REGEX": "^VB"}}]
+            }
+        ]
+
+
 
 class TestStandalone(object):
     @property

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -302,6 +302,37 @@ class TestSpacy(object):
             "pattern": [{"TAG": {"REGEX": "^NN|^JJ"}}]
         }
 
+    def test_tag_word(self):
+        rules = self.compiler("""
+        !IMPORT("rita.modules.tag")
+
+        TAG_WORD("^VB", "proposed")->MARK("TEST_TAG")
+        """)
+
+        print(rules)
+
+        assert len(rules) == 1
+        assert rules[0] == {
+            "label": "TEST_TAG",
+            "pattern": [{"LOWER": "proposed", "TAG": {"REGEX": "^VB"}}]
+        }
+
+    def test_tag_list(self):
+        rules = self.compiler("""
+        !IMPORT("rita.modules.tag")
+
+        words = {"perceived", "proposed"}
+        {TAG_WORD("^VB", words)}->MARK("TEST_TAG")
+        """)
+
+        print(rules)
+
+        assert len(rules) == 1
+        assert rules[0] == {
+            "label": "TEST_TAG",
+            "pattern": [{"LOWER": {"REGEX": "^(perceived|proposed)$"}, "TAG": {"REGEX": "^VB"}}]
+        }
+
 
 class TestStandalone(object):
     @property

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -358,7 +358,6 @@ class TestSpacy(object):
         ]
 
 
-
 class TestStandalone(object):
     @property
     def punct(self):


### PR DESCRIPTION
This feature would introduce the TAG_WORD element to the Tag module

`TAG_WORD` is for generating TAG patterns with a word or a list.

e.g. match only "proposed" when it is in the sentence a verb (and not an adjective):

```
!IMPORT("rita.modules.tag")

TAG_WORD("^VB", "proposed")
```

or e.g. match a list of words only to verbs

```
!IMPORT("rita.modules.tag")

words = {"percived", "proposed"}
{TAG_WORD("^VB", words)}->MARK("LABEL")
```